### PR TITLE
Added tracking to download buttons

### DIFF
--- a/_includes/_ui.html
+++ b/_includes/_ui.html
@@ -20,8 +20,12 @@
 
   <div class="ui-foldout" data-ui-foldout="download">
     <div class="ui-buttons">
-      <a href="http://www.saent.com/downloads/Saent-Installer.pkg" class="btn--blue">Download for OSX</a>
-      <a href="http://www.saent.com/downloads/Saent4WinSetup.msi" class="btn--blue">Download for Windows</a>
+      <a href="http://www.saent.com/downloads/Saent-Installer.pkg"
+          onclick="Analytics().trackMacDownload()"
+          class="btn--blue">Download for OSX</a>
+      <a href="http://www.saent.com/downloads/Saent4WinSetup.msi"
+          onclick="Analytics().trackWindowsDownload()"
+          class="btn--blue">Download for Windows</a>
     </div>
   </div>
 </div>

--- a/_includes/download.html
+++ b/_includes/download.html
@@ -1,8 +1,10 @@
 <section class="download" data-section="download" id="subscribe">
   <div class="download-illustration">
     <div class="download-buttons">
-      <a href="http://www.saent.com/downloads/Saent-Installer.pkg" class="btn">Download for OSX</a>
-      <a href="http://www.saent.com/downloads/Saent4WinSetup.msi" class="btn">Download for Windows</a>
+      <a onclick="Analytics().trackMacDownload()"
+          href="http://www.saent.com/downloads/Saent-Installer.pkg" class="btn">Download for OSX</a>
+      <a onclick="Analytics().trackWindowsDownload()"
+          href="http://www.saent.com/downloads/Saent4WinSetup.msi" class="btn">Download for Windows</a>
 
     </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,5 +24,6 @@
   <script type="text/javascript" src="/js/scroll-section.js"></script>
   <script type="text/javascript" src="/js/dropdown.js"></script>
   <script type="text/javascript" src="/js/categorizing.js"></script>
+  <script type="text/javascript" src="/js/analytics.js"></script>
   <script type="text/javascript" src="/js/main.js"></script>
 </html>

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,26 @@
+var Analytics = function() {
+
+  this.trackMacDownload = function() {
+
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'Downloads',
+      eventAction: 'download saent for mac',
+      eventLabel: 'Download Saent for Mac',
+      transport: 'beacon'
+    });
+  }
+
+  this.trackWindowsDownload = function() {
+
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'Downloads',
+      eventAction: 'download saent for windows',
+      eventLabel: 'Download Saent for Windows',
+      transport: 'beacon'
+    });
+  }
+
+  return this;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -2,3 +2,4 @@ ProgressBar();
 ScrollSection();
 Dropdown();
 Categorizing();
+Analytics();


### PR DESCRIPTION
This PR adds the ability to track mac and windows downloads in google analytics.

Right now, it's working with a dummy account that I have setup. Once it's approved, I'll switch it back over to saent's GA.

It's pretty simple. You click on a download button, and an event is registered in GA. Windows events are labeled `Download Saent for Windows` and Mac events are labeled `Download Saent for Mac`.

@caleboller I added you to the dummy GA account so you can test it.
